### PR TITLE
Remove unused isort config file

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,0 @@
-[settings]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88


### PR DESCRIPTION
pyproject.toml is now used, with the isort 5+ profile = black