### PR TITLE
Combine config files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,0 @@
-[run]
-branch = True
-omit =
-	setup.py
-
-[report]
-exclude_lines =
-	assert
-	pragma: no cover

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-extend-ignore = E203, E501

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ addopts =
     -ra
     --ds=tests.settings
     --cov auto_prefetch
+    --cov tests
     --cov-report=term-missing:skip-covered
     --no-cov-on-fail
     --cov-fail-under=100

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,18 @@ zip_safe = False
 [options.packages.find]
 where = src
 
+[coverage:run]
+branch = True
+
+[coverage:paths]
+source =
+   src
+   .tox/*/site-packages
+
+[coverage:report]
+show_missing = True
+
 [flake8]
 max-line-length = 80
 select = C,E,F,W,B,B950
-ignore = E501,W503
+ignore = E203,E501,W503


### PR DESCRIPTION
* Move coverage config into setup.cfg
* Remove now ignored flake8 config file, as setup.cfg configures it
* Make pytest `--cov` option cover tests too
* Tweak flake8 config to match black recommendations