### PR TITLE
Black target Python version 3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 40.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py38']
+target-version = ['py35']
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Target the minimum supported Python version so it doesn't accidentally introduce incompatible syntax.