### PR TITLE
Use latest GitHub Actions setup-python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2.1.1
+    - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/cache@v2


### PR DESCRIPTION
This should stop this deprecation warning: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

We only pinned to a specific patch version since we needed the version that supported installing the latest Python. That's now been released onto the main `v2` tag/branch.