### PR TITLE
Add missing release note for Django 3.2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,8 @@
+=======
 History
 =======
+
+* Support Django 3.2.
 
 * Add system check that the ``Meta`` class is inherited in all subclasses.
 


### PR DESCRIPTION
Also standardize header so future regex insertion automatically adds it.