### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,12 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,10 @@ repos:
   - id: reorder-python-imports
     args:
     - --py37-plus
+    - --application-directories
+    - src:tests
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 check_untyped_defs = true
 disallow_any_generics = true

--- a/src/auto_prefetch/__init__.py
+++ b/src/auto_prefetch/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
+from typing import TYPE_CHECKING
 from weakref import WeakValueDictionary
 
 from django.core import checks

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import auto_prefetch
 from django.db import models
+
+import auto_prefetch
 
 
 class Friend(models.Model):

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from django.db import models
-
 import auto_prefetch
+from django.db import models
 
 
 class Friend(models.Model):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import gc
 import pickle
 
-import auto_prefetch
 import pytest
 from django.core.exceptions import ObjectDoesNotExist
 
+import auto_prefetch
 from . import models
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import gc
 import pickle
 
+import auto_prefetch
 import pytest
 from django.core.exceptions import ObjectDoesNotExist
-
-import auto_prefetch
 
 from . import models
 


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
