### PR TITLE
Remove build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-rm -Rf dist build
-pip install --upgrade setuptools wheel twine
-python setup.py sdist bdist_wheel
-python -m twine upload -u __token__ dist/*


### PR DESCRIPTION
Unused since I took over releases, and outdated since it doesn't use 'python -m build'. Script used these days: https://github.com/adamchainz/scripts/blob/main/package-release.py